### PR TITLE
added processing notebooks and combined domain count file

### DIFF
--- a/code/20160612-eot-cdx-analysis.ipynb
+++ b/code/20160612-eot-cdx-analysis.ipynb
@@ -1,0 +1,611 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## EOT CDX file analysis\n",
+    "\n",
+    "Working with the already-transformed parquet files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "\n",
+    "from pyspark.sql import Row\n",
+    "from pyspark.sql.functions import lit, udf\n",
+    "from pyspark.sql.types import ArrayType, DateType, StringType"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df08 = sqlContext.read.parquet(\"eot2008.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "df12 = sqlContext.read.parquet(\"eot2012.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.4 ms, sys: 196 µs, total: 2.6 ms\n",
+      "Wall time: 7.32 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "160212140"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%time df08.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.83 ms, sys: 152 µs, total: 1.98 ms\n",
+      "Wall time: 5.96 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "194066937"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%time df12.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('surt_uri', 'string'),\n",
+       " ('capture_time', 'string'),\n",
+       " ('original_uri', 'string'),\n",
+       " ('mime_type', 'string'),\n",
+       " ('response_code', 'string'),\n",
+       " ('hash_sha1', 'string'),\n",
+       " ('redirect_url', 'string'),\n",
+       " ('meta_tags', 'string'),\n",
+       " ('length_compressed', 'string'),\n",
+       " ('warc_offset', 'string'),\n",
+       " ('warc_name', 'string')]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df08.dtypes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Questions for reformatting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Extract date to new Date column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def extract_date(s):\n",
+    "    return '%s-%s-%s' % (s[0:4], s[4:6], s[6:8])\n",
+    "\n",
+    "date_extractor = udf(extract_date, StringType())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "df08_date = df08.withColumn(\"capture_date\", date_extractor(df08[\"capture_time\"]).cast(\"date\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df08_date.take(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Extract domain components to columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def extract_domain(s, level):\n",
+    "    domain = s.split(')')[0].split(',')\n",
+    "    level = int(level)\n",
+    "    if len(domain) > level:\n",
+    "        return domain[level]\n",
+    "    return ''\n",
+    "\n",
+    "domain_extractor = udf(extract_domain, StringType())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "...this is inelegant..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df08_dom1 = df08.withColumn(\"dom1\", domain_extractor(df08[\"surt_uri\"], lit('0')))\n",
+    "df08_dom2 = df08_dom1.withColumn(\"dom2\", domain_extractor(df08_dom1[\"surt_uri\"], lit('1')))\n",
+    "df08_dom3 = df08_dom2.withColumn(\"dom3\", domain_extractor(df08_dom2[\"surt_uri\"], lit('2')))\n",
+    "df08_dom4 = df08_dom3.withColumn(\"dom4\", domain_extractor(df08_dom3[\"surt_uri\"], lit('3')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "DataFrame[surt_uri: string, capture_time: string, original_uri: string, mime_type: string, response_code: string, hash_sha1: string, redirect_url: string, meta_tags: string, length_compressed: string, warc_offset: string, warc_name: string, dom1: string, dom2: string, dom3: string, dom4: string]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df08_dom4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Hmm, that worked, but let's just go the sql route for now."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df08.registerTempTable(\"eot08\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sql = \"\"\"\n",
+    "    SELECT SUBSTRING(surt_uri, 0, INSTR(surt_uri, \")\") - 1) AS surt, COUNT(*) AS count\n",
+    "    FROM eot08\n",
+    "    GROUP BY SUBSTRING(surt_uri, 0, INSTR(surt_uri, \")\") - 1)\n",
+    "    ORDER BY count DESC\n",
+    "    \"\"\"\n",
+    "domains08 = sqlContext.sql(sql)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "domains08.rdd.map(lambda x: \"\\t\".join(map(str, x))).coalesce(1).saveAsTextFile(\"eot08-domains.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "df12.registerTempTable(\"eot12\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "sql = \"\"\"\n",
+    "    SELECT SUBSTRING(surt_uri, 0, INSTR(surt_uri, \")\") - 1) AS surt, COUNT(*) AS count\n",
+    "    FROM eot12\n",
+    "    GROUP BY SUBSTRING(surt_uri, 0, INSTR(surt_uri, \")\") - 1)\n",
+    "    ORDER BY count DESC\n",
+    "    \"\"\"\n",
+    "domains12 = sqlContext.sql(sql)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "domains12.rdd.map(lambda x: \"\\t\".join(map(str, x))).coalesce(1).saveAsTextFile(\"eot12-domains.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "141090"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "domains08.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "domains08 = domains08.withColumnRenamed(\"surt\", \"surt08\").withColumnRenamed(\"count\", \"count08\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "353280"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "domains12.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "domains12 = domains12.withColumnRenamed(\"surt\", \"surt12\").withColumnRenamed(\"count\", \"count12\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "domains_combined = domains08.join(domains12, domains08.surt08 == domains12.surt12, 'outer')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('surt08', 'string'),\n",
+       " ('count08', 'bigint'),\n",
+       " ('surt12', 'string'),\n",
+       " ('count12', 'bigint')]"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "domains_combined.dtypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "domains_combined.rdd.map(lambda x: \"\\t\".join(map(str, x))).coalesce(1).saveAsTextFile(\"combined-domains.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "444186"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "domains_combined.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def either(a, b):\n",
+    "    if a:\n",
+    "        return a\n",
+    "    return b\n",
+    "\n",
+    "udf_either = udf(either, StringType())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 66,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "domains_combined = domains_combined.withColumn(\"surt\", udf_either(domains_combined[\"surt08\"], domains_combined[\"surt12\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Row(surt08=None, count08=None, surt12='100,99,67,134', count12=31, surt='100,99,67,134'),\n",
+       " Row(surt08=None, count08=None, surt12='118,72,133,174', count12=13, surt='118,72,133,174'),\n",
+       " Row(surt08='2,94,223,66', count08=31, surt12='2,94,223,66', count12=37, surt='2,94,223,66'),\n",
+       " Row(surt08=None, count08=None, surt12='218,120,100,94', count12=3, surt='218,120,100,94'),\n",
+       " Row(surt08=None, count08=None, surt12='249,58,254,173', count12=3, surt='249,58,254,173'),\n",
+       " Row(surt08='58,78,12,76', count08=2, surt12=None, count12=None, surt='58,78,12,76'),\n",
+       " Row(surt08=None, count08=None, surt12='67,254,207,130:7123', count12=2, surt='67,254,207,130:7123'),\n",
+       " Row(surt08=None, count08=None, surt12='af,afghanistan,cdn', count12=38, surt='af,afghanistan,cdn'),\n",
+       " Row(surt08='am,circle', count08=50, surt12='am,circle', count12=62, surt='am,circle'),\n",
+       " Row(surt08=None, count08=None, surt12='ar,com,latinvia', count12=9, surt='ar,com,latinvia'),\n",
+       " Row(surt08=None, count08=None, surt12='ar,com,tutoloquequieras,com,flickr', count12=2, surt='ar,com,tutoloquequieras,com,flickr'),\n",
+       " Row(surt08='at,ac,tuwien,atp,magnet', count08=15, surt12=None, count12=None, surt='at,ac,tuwien,atp,magnet'),\n",
+       " Row(surt08=None, count08=None, surt12='at,oewabox,ichkoche', count12=5, surt='at,oewabox,ichkoche'),\n",
+       " Row(surt08=None, count08=None, surt12='at,pressreleases', count12=32, surt='at,pressreleases'),\n",
+       " Row(surt08=None, count08=None, surt12='au,com,fairfax', count12=2, surt='au,com,fairfax'),\n",
+       " Row(surt08=None, count08=None, surt12='au,com,fishpond', count12=108, surt='au,com,fishpond'),\n",
+       " Row(surt08=None, count08=None, surt12='au,com,google,books,bks6', count12=55, surt='au,com,google,books,bks6'),\n",
+       " Row(surt08=None, count08=None, surt12='au,com,lgnews,staging', count12=7, surt='au,com,lgnews,staging'),\n",
+       " Row(surt08=None, count08=None, surt12='au,com,lwt', count12=5, surt='au,com,lwt'),\n",
+       " Row(surt08='au,com,milkwoodpermaculture', count08=3, surt12=None, count12=None, surt='au,com,milkwoodpermaculture')]"
+      ]
+     },
+     "execution_count": 67,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "domains_combined.take(20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "domains_combined = domains_combined.drop(\"surt08\").drop(\"surt12\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "domains_combined = domains_combined.na.fill(0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "domains_combined.rdd.map(lambda x: \"\\t\".join(map(str, x))).coalesce(1).saveAsTextFile(\"domains-combined.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/code/20160612-eot-cdx-to-parquet.ipynb
+++ b/code/20160612-eot-cdx-to-parquet.ipynb
@@ -1,0 +1,178 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Converting incoming CDX files to Parquet\n",
+    "\n",
+    "Quick look at file sizes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "-rw-rw-r-- 1 ubuntu ubuntu 9.5G May 18 17:56 eot2012_surt_index.cdx.gz\r\n",
+      "-rw-rw-r-- 1 ubuntu ubuntu   60 May 18 17:50 eot2012_surt_index.cdx.gz.md5\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls -lh eot2012_surt_index.cdx*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note: Spark can typically load `*.gz` files just fine, but that support comes from Hive integration, which seems to be missing here.  So gunzip first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "!gunzip eot2012_surt_index.cdx.gz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load in the unzipped file, filetering out any line that starts with a blank or has essentially no content."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "eot2012 = sc.textFile(\"eot2012_surt_index.cdx\") \\\n",
+    "  .filter(lambda line: line[0] != ' ') \\\n",
+    "  .filter(lambda line: len(line)>1) \\\n",
+    "  .map(lambda line: line.split(\" \")) \\\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Prep a dataframe from the RDD, naming columns appropriately. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df = sqlContext.createDataFrame(eot2012)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "df = df.withColumnRenamed(\"_1\", \"surt_uri\") \\\n",
+    "    .withColumnRenamed(\"_2\", \"capture_time\") \\\n",
+    "    .withColumnRenamed(\"_3\", \"original_uri\") \\\n",
+    "    .withColumnRenamed(\"_4\", \"mime_type\") \\\n",
+    "    .withColumnRenamed(\"_5\", \"response_code\") \\\n",
+    "    .withColumnRenamed(\"_6\", \"hash_sha1\") \\\n",
+    "    .withColumnRenamed(\"_7\", \"redirect_url\") \\\n",
+    "    .withColumnRenamed(\"_8\", \"meta_tags\") \\\n",
+    "    .withColumnRenamed(\"_9\", \"length_compressed\") \\\n",
+    "    .withColumnRenamed(\"_10\", \"warc_offset\") \\\n",
+    "    .withColumnRenamed(\"_11\", \"warc_name\") \\"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Write out as Parquet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "df.write.parquet(\"eot2012.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8.1G\teot2012.parquet\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!du -hs eot2012.parquet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "This final step took 15 minutes on an r3.4xlarge, using 3.9 hours of compute time."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
The notebooks cover converting the data into parquet and generating the combined count file.

The combined count file includes total urls grouped by surt for both 2008 and 2012.
